### PR TITLE
Fix encoding stalling by interleaving audio and video

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,6 +24,7 @@ let package = Package(
                 .process("Resources/test-no-audio.mp4"),
                 .process("Resources/test-no-video.m4a"),
                 .process("Resources/test-spatial-audio.mov"),
+                .process("Resources/test-x264-1080p-h264-60fps.mp4"),
             ]
         ),
     ]


### PR DESCRIPTION
Thanks to the AVFoundation team I learned that both audio and video samples are supposed to be interleaved whenever media data is ready from either call to encode ready samples, and that fixes encoding this video encoding with x264 and ffmpeg.